### PR TITLE
Fix for non existent file decrypt issue

### DIFF
--- a/patches/decrypt.c.patch
+++ b/patches/decrypt.c.patch
@@ -1,15 +1,25 @@
 diff --git a/g10/decrypt.c b/g10/decrypt.c
-index cb9e36a..9314d23 100644
+index fb606cb..226388b 100644
 --- a/g10/decrypt.c
 +++ b/g10/decrypt.c
-@@ -53,7 +53,9 @@ decrypt_message (ctrl_t ctrl, const char *filename)
+@@ -62,11 +62,16 @@ decrypt_message (ctrl_t ctrl, const char *filename, strlist_t remusr)
  
    /* Open the message file.  */
    fp = iobuf_open (filename);
 -  if (fp && is_secured_file (iobuf_get_fd (fp)))
-+  int fd =iobuf_get_fd (fp);
-+  __disableautocvt(fd);
-+  if (fp && is_secured_file (fd))
++  if (fp)
      {
-       iobuf_close (fp);
-       fp = NULL;
+-      iobuf_close (fp);
+-      fp = NULL;
+-      gpg_err_set_errno (EPERM);
++      int fd = iobuf_get_fd (fp);
++      __disableautocvt(fd);
++      if (is_secured_file (fd))
++        {
++          iobuf_close (fp);
++          fp = NULL;
++          gpg_err_set_errno (EPERM);
++        }
+     }
+   if ( !fp )
+     {

--- a/patches/stringhelp.c.patch
+++ b/patches/stringhelp.c.patch
@@ -1,0 +1,14 @@
+diff --git a/common/stringhelp.c b/common/stringhelp.c
+index 8bbc68a..5dee32f 100644
+--- a/common/stringhelp.c
++++ b/common/stringhelp.c
+@@ -50,6 +50,9 @@
+ # include <windows.h>
+ #endif
+ #include <limits.h>
++#ifdef __MVS__
++#include <string.h>
++#endif
+ 
+ #include "util.h"
+ #include "common-defs.h"


### PR DESCRIPTION
When the file does not exist, `iobuf_open(filename)` returns `NULL`. The code then immediately calls
`  iobuf_get_fd(fp)`.
`iobuf_get_fd` does not check if the input pointer is `NULL`
This results in the `SIGSEGV`.
`fp` is checked for `NULL` before calling `iobuf_get_fd(fp)`